### PR TITLE
show only confirmed strings

### DIFF
--- a/core/segment.go
+++ b/core/segment.go
@@ -28,8 +28,19 @@ func (m *Classes) Segments(first int) (result []Segment) {
 			since = until
 			first = class
 		}
+
+		if until == len(m.X) -1 && since != until {
+			result = append(result, Segment{
+				Class: first == 1,
+				Since: since,
+				Until: until,
+				Width: float64(until - since),
+				Level: med64(m.X[since:until]),
+			})
+		}
 	}
-	if len(result) > 1 {
+
+	if len(result) > 2 {
 		return result[1:]
 	} else {
 		return nil

--- a/core/symbols.go
+++ b/core/symbols.go
@@ -22,9 +22,6 @@ func init() {
 	for key, value := range forward {
 		reverse[value] = key
 	}
-	for key, value := range forward {
-		reverse[value] = key
-	}
 	reverse[" "] = ""
 	reverse[""] = ""
 }
@@ -41,9 +38,9 @@ func CodeToText(code string) (result string) {
 	if len(code) > 0 {
 		if code[len(code)-1:] != " " {
 			result = result[:len(result)-1]
-		} 
+		}
 	}
-	
+
 	return
 }
 

--- a/core/symbols.go
+++ b/core/symbols.go
@@ -22,6 +22,11 @@ func init() {
 	for key, value := range forward {
 		reverse[value] = key
 	}
+	for key, value := range forward {
+		reverse[value] = key
+	}
+	reverse[" "] = ""
+	reverse[""] = ""
 }
 
 func CodeToText(code string) (result string) {
@@ -32,6 +37,13 @@ func CodeToText(code string) (result string) {
 			result += "?"
 		}
 	}
+
+	if len(code) > 0 {
+		if code[len(code)-1:] != " " {
+			result = result[:len(result)-1]
+		} 
+	}
+	
 	return
 }
 


### PR DESCRIPTION
https://github.com/nextzlog/todo/issues/191
確定した文字のみ表示するための実装案です。
```
最後の文字が解読される
↓
文字間の空白が出るのでmissは増えない
↓
文字間の空白でそのままなのでmissが増える
↓
解読終了
```
となるように修正し、最後の文字が空白なら表示、最後の文字が空白でない場合は最後の文字は怪しい（それより前の文字は確定している）という考えに基づき実装しています。

ご確認の程よろしくお願いします。